### PR TITLE
Mobile navigation bar

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -7,16 +7,6 @@ import CookieConsent from 'react-cookie-consent'
 import NavigationBar from 'components/NavigationBar'
 import Footer from 'components/Footer'
 
-const menuItems = [
-    { label: 'Projects', url: '/projects' },
-    { label: 'Members', url: '/members' },
-    // { label: 'Learn', url: '/learn' },
-    { label: 'Community', url: 'https://ownemployed.tribe.so/' },
-    { label: 'Account', url: '/profile', isPrivate: true },
-    { label: 'Create project', url: '/create-project', isPrivate: true },
-    { label: 'My Account', url: '/signup', isAuth: true },
-]
-
 const Main = ({ children, boxed }) => {
     return (
         <Box
@@ -46,7 +36,7 @@ const Layout = ({ children, boxed = true }) => {
                     padding: 0,
                 }}
             >
-                <NavigationBar items={menuItems} />
+                <NavigationBar />
                 <Main boxed={boxed}>{children}</Main>
                 <CookieConsent
                     acceptOnScroll={true}

--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -1,62 +1,101 @@
 import React from 'react'
 import { NavLink } from 'components/NavLink'
-import { Flex, Box, Image, Button } from 'rebass'
-import { Link } from 'react-router-dom'
+import { Flex, Image, Link as RebassLink } from 'rebass'
 import logo from 'static/ownemployed_logo.png'
 import { useAuth0 } from 'lib/react-auth0-spa'
+import { BsList } from 'react-icons/bs'
+import { useIsMobile } from 'hooks/useIsMobile'
+import { NavigationItemData } from './navigation/types'
+import { NavigationItems } from './navigation/NavigationItems'
+import { MobileNavigationItems } from './navigation/MobileNavigationItems'
 
-type NavigationItem = {
-    label: string
-    url: string
-    isPrivate?: boolean
-    isAuth?: boolean
+const FIND_PROJECTS = {
+    label: 'Find Projects',
+    url: '/projects',
+    subtext: 'Find projects that are right for you and need your help.',
 }
+const FIND_MEMBERS = {
+    label: 'Find Members',
+    url: '/members',
+    subtext: 'Find people with the skills your project needs.',
+}
+const COMMUNITY = { label: 'Community', url: 'https://ownemployed.tribe.so/' }
+
+const MOBILE_MENU_ITEMS: NavigationItemData[] = [
+    FIND_PROJECTS,
+    FIND_MEMBERS,
+    COMMUNITY,
+]
+
+const MENU_ITEMS: NavigationItemData[] = [
+    FIND_PROJECTS,
+    FIND_MEMBERS,
+    // { label: 'Learn', url: '/learn' },
+    COMMUNITY,
+    { label: 'Account', url: '/profile', isPrivate: true },
+    { label: 'Create project', url: '/create-project', isPrivate: true },
+    { label: 'My Account', url: '/signup', isAuth: true },
+]
 
 const Brand = () => {
     return (
         <NavLink to="/">
-            <Image alt="logo" src={logo} width="245px" />
+            <Image alt="logo" src={logo} width="245px" id="navigation--logo" />
         </NavLink>
     )
 }
 
-const NavigationBar = ({ items }: { items: NavigationItem[] }) => {
-    const { isAuthenticated, loginWithRedirect, logout } = useAuth0()
+const NavigationBar = () => {
+    const { isAuthenticated } = useAuth0()
+    const isMobile = useIsMobile()
+
+    const [show, setShow] = React.useState(false)
 
     return (
-        <Flex pl={5} pr={5} color="black" alignItems="center" bg="#fff">
-            <Brand />
-            <Box mr="auto" />
-            <Flex alignItems="center">
-                {items
-                    .filter(item => {
-                        // NOTE check if private, then return the results of isAuthenticated
-                        return item.isPrivate ? isAuthenticated : true
-                    })
-                    .map((item, index) => {
-                        if (item.isAuth) {
-                            return (
-                                <Button>
-                                    <Link
-                                        style={{
-                                            textDecoration: 'none',
-                                            color: 'white',
-                                        }}
-                                        key={index}
-                                        to={item.url}
-                                    >
-                                        {item.label}
-                                    </Link>
-                                </Button>
-                            )
-                        }
-                        return (
-                            <NavLink key={index} to={item.url}>
-                                {item.label}
-                            </NavLink>
-                        )
-                    })}
+        <Flex
+            color="black"
+            alignItems={['strech', 'center']}
+            bg="#fff"
+            flexDirection={['column', 'row']}
+            justifyContent="space-around"
+            id="navigation-header"
+            width="100%"
+        >
+            <Flex
+                pl={[0, 5]}
+                pr={[0, 5]}
+                flexDirection={['row', 'column']}
+                justifyContent="space-around"
+            >
+                <Brand />
+                <RebassLink
+                    variant="nav"
+                    onClick={() => setShow(!show)}
+                    display={['visble', 'none']}
+                    sx={{
+                        backgroundColor: 'transparent',
+                        color: 'black',
+                        alignSelf: 'flex-end',
+                        fontSize: '2rem',
+                    }}
+                >
+                    <BsList />
+                </RebassLink>
             </Flex>
+
+            {isMobile && show && (
+                <MobileNavigationItems
+                    items={MOBILE_MENU_ITEMS}
+                    isAuthenticated={isAuthenticated}
+                    close={() => setShow(false)}
+                />
+            )}
+            {!isMobile && (
+                <NavigationItems
+                    items={MENU_ITEMS}
+                    isAuthenticated={isAuthenticated}
+                />
+            )}
         </Flex>
     )
 }

--- a/src/components/navigation/MobileNavigationItems.tsx
+++ b/src/components/navigation/MobileNavigationItems.tsx
@@ -1,0 +1,79 @@
+import React from 'react'
+import { NavigationItemData } from './types'
+import { Flex, Box, Button } from 'rebass'
+import { NavigationButton } from './NavigationButton'
+import { FaTimes } from 'react-icons/fa'
+import { NavigationItem } from './NavigationItem'
+
+export function MobileNavigationItems({
+    items,
+    isAuthenticated,
+    close,
+}: {
+    items: NavigationItemData[]
+    isAuthenticated: any
+    close: () => void
+}) {
+    return (
+        <Box
+            id="navigation--items"
+            sx={{
+                position: 'absolute',
+                top: '1rem',
+                right: '1rem',
+                backgroundColor: 'primary',
+                width: '80%',
+                boxShadow: '0px 3px 6px rgba(92, 92, 92, 0.25)',
+                borderRadius: '4px',
+            }}
+        >
+            <Flex flexDirection="column">
+                <Flex justifyContent="space-around" pt={1}>
+                    <Flex>
+                        {!isAuthenticated && (
+                            <NavigationButton
+                                url={'/signup'}
+                                label={'Sign in'}
+                            />
+                        )}
+                        {isAuthenticated && (
+                            <NavigationButton
+                                url={'/signout'}
+                                label={'Sign out'}
+                            />
+                        )}
+                        <NavigationButton
+                            url={'/create-project'}
+                            label={'Start a project'}
+                        />
+                    </Flex>
+                    <Box alignSelf="flex-end">
+                        <Button
+                            variant="outline"
+                            fontSize="1.5rem"
+                            pt="2"
+                            onClick={close}
+                        >
+                            <FaTimes />
+                        </Button>
+                    </Box>
+                </Flex>
+                <Flex
+                    flexDirection="column"
+                    sx={{ backgroundColor: 'primaryLight' }}
+                >
+                    {items.map(item => {
+                        return (
+                            <NavigationItem
+                                key={item.url}
+                                url={item.url}
+                                label={item.label}
+                                subtext={item.subtext}
+                            />
+                        )
+                    })}
+                </Flex>
+            </Flex>
+        </Box>
+    )
+}

--- a/src/components/navigation/NavigationButton.tsx
+++ b/src/components/navigation/NavigationButton.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { Button } from 'rebass'
+import { Link } from 'react-router-dom'
+
+export function NavigationButton(props: { url: string; label: string }) {
+    return (
+        <Button variant="secondaryOutlined" alignSelf="center" mx={2}>
+            <Link
+                className="navigation--button"
+                style={{
+                    textDecoration: 'none',
+                    color: 'white',
+                }}
+                key={props.url}
+                to={props.url}
+            >
+                {props.label}
+            </Link>
+        </Button>
+    )
+}

--- a/src/components/navigation/NavigationItem.tsx
+++ b/src/components/navigation/NavigationItem.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { Text } from 'components/Text'
+import { Link as RebassLink } from 'rebass'
+
+export function NavigationItem(props: {
+    url: string
+    label: string
+    subtext?: string
+}) {
+    return (
+        <RebassLink
+            className="navigation--item"
+            key={props.url}
+            href={props.url}
+            p={2}
+            sx={{
+                color: ['white', 'primary'],
+                ':visited': { color: ['white', 'primary'] },
+                textDecoration: ['none', 'underline'],
+                fontWeight: ['bold', 'normal'],
+                backgroundColor: ['primaryLight', 'white'],
+            }}
+        >
+            {props.label}
+            {props.subtext && (
+                <Text
+                    className="navigation--subtext"
+                    sx={{
+                        color: 'secondaryGrey',
+                        display: ['block', 'none'],
+                    }}
+                >
+                    {props.subtext}
+                </Text>
+            )}
+        </RebassLink>
+    )
+}

--- a/src/components/navigation/NavigationItems.tsx
+++ b/src/components/navigation/NavigationItems.tsx
@@ -1,0 +1,47 @@
+import { NavigationItemData } from './types'
+import React from 'react'
+import { Flex } from 'rebass'
+import { NavigationButton } from './NavigationButton'
+import { NavigationItem } from './NavigationItem'
+
+export function NavigationItems({
+    items,
+    isAuthenticated,
+}: {
+    items: NavigationItemData[]
+    isAuthenticated: any
+}) {
+    return (
+        <Flex
+            id="navigation--items"
+            sx={{
+                flexDirection: ['column', 'row'],
+            }}
+        >
+            {items
+                .filter(item => {
+                    // NOTE check if private, then return the results of isAuthenticated
+                    return item.isPrivate ? isAuthenticated : true
+                })
+                .map(item => {
+                    if (item.isAuth) {
+                        return (
+                            <NavigationButton
+                                key={item.url}
+                                url={item.url}
+                                label={item.label}
+                            />
+                        )
+                    }
+                    return (
+                        <NavigationItem
+                            key={item.url}
+                            url={item.url}
+                            label={item.label}
+                            subtext={item.subtext}
+                        />
+                    )
+                })}
+        </Flex>
+    )
+}

--- a/src/components/navigation/types.ts
+++ b/src/components/navigation/types.ts
@@ -1,0 +1,7 @@
+export interface NavigationItemData {
+    label: string
+    url: string
+    subtext?: string
+    isPrivate?: boolean
+    isAuth?: boolean
+}

--- a/src/config/theme.ts
+++ b/src/config/theme.ts
@@ -12,6 +12,7 @@ export default {
     colors: {
         primary: '#6F63AD',
         primaryHover: '#D0CDE1',
+        primaryLight: '#6E6895',
         secondary: '#124780',
         secondaryHover: '#FFE180',
         alert: '#FF5252',
@@ -21,6 +22,7 @@ export default {
         heading: '#000000',
         body: '#768598',
         white: '#fff',
+        secondaryGrey: '#c4c4c4',
     },
     space: [0, 4, 8, 16, 32, 64, 128, 256],
     fonts: {
@@ -99,6 +101,18 @@ export default {
             color: 'primary',
             borderRadius: 'button',
             border: '1px solid',
+            boxSizing: 'border-box',
+            padding: '6px 8px 6px 8px',
+            '&:hover': {
+                borderColor: 'primaryHover',
+                cursor: 'pointer',
+            },
+        },
+        secondaryOutlined: {
+            backgroundColor: 'primary',
+            color: 'white',
+            borderRadius: 'button',
+            border: '1px solid white',
             boxSizing: 'border-box',
             padding: '6px 8px 6px 8px',
             '&:hover': {

--- a/src/hooks/useIsMobile.ts
+++ b/src/hooks/useIsMobile.ts
@@ -1,0 +1,18 @@
+import { useWindowSize } from './useWindowSize'
+import theme from '../config/theme'
+
+const MOBILE_WIDTH = theme.breakpoints[0]
+
+function convertRemToPixels(em: string) {
+    const emUnits = parseInt(em.split('em')[0])
+
+    return (
+        emUnits *
+        parseFloat(getComputedStyle(document.documentElement).fontSize)
+    )
+}
+
+export function useIsMobile() {
+    const windowSize = useWindowSize()
+    return windowSize.innerWidth <= convertRemToPixels(MOBILE_WIDTH)
+}

--- a/src/hooks/useWindowSize.ts
+++ b/src/hooks/useWindowSize.ts
@@ -1,0 +1,34 @@
+import * as React from 'react'
+
+export interface WindowSize {
+    innerHeight: number
+    innerWidth: number
+    outerHeight: number
+    outerWidth: number
+}
+
+function getSize(): WindowSize {
+    return {
+        innerHeight: window.innerHeight,
+        innerWidth: window.innerWidth,
+        outerHeight: window.outerHeight,
+        outerWidth: window.outerWidth,
+    }
+}
+
+export function useWindowSize(): WindowSize {
+    const [windowSize, setWindowSize] = React.useState(getSize())
+
+    function handleResize() {
+        setWindowSize(getSize())
+    }
+
+    React.useEffect(() => {
+        window.addEventListener('resize', handleResize)
+        return () => {
+            window.removeEventListener('resize', handleResize)
+        }
+    })
+
+    return windowSize
+}


### PR DESCRIPTION
Adds a mobile version of the navigation menu.

I'm not particularly happy with the implementing here, the design for the mobile view differs quite a bit structure wise, from the main navigation bar. 
I'd appreciate some feedback on if this could be done another way

To accommodate, I've split the navigation into 2 pieces, mobile vs desktop.

The primary control for this is via a new hook, which detects the screen size, using the breakpoints defined in the theme config.

I'm not sure we have all the pages available/active yet. So this will likely need further tweaks. Hopefully it is simple enough to extend when other pages are ready. 
Disappointingly I've split the config into 2, as the same structure doesn't work for mobile and desktop.

I've also not used Rebass before this project, so I'm unsure on the best practice of implementing some of the styling. I've tried to stick to Rebass/internal components.


## Screenshots
Desktop
<img width="1265" alt="Screenshot 2020-06-16 at 21 38 16" src="https://user-images.githubusercontent.com/879073/84826478-e7093500-b01a-11ea-985b-6341e5bdada1.png">

Mobile Open:
<img width="564" alt="Screenshot 2020-06-16 at 21 38 02" src="https://user-images.githubusercontent.com/879073/84826491-ecff1600-b01a-11ea-94d1-819606eb5175.png">

Mobile closed:
<img width="598" alt="Screenshot 2020-06-16 at 21 37 56" src="https://user-images.githubusercontent.com/879073/84826510-f1c3ca00-b01a-11ea-879b-0d4cb5afe356.png">

